### PR TITLE
Initialize _suspend and _lastRunTime in MD_PZone constructor

### DIFF
--- a/src/MD_PZone.cpp
+++ b/src/MD_PZone.cpp
@@ -27,7 +27,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  * \brief Implements MD_PZone class methods
  */
 
-MD_PZone::MD_PZone(void) : _fsmState(END), _scrollDistance(0), _zoneEffect(0), _userChars(nullptr),
+MD_PZone::MD_PZone(void) :
+_suspend(false), _lastRunTime(0),
+_fsmState(END), _scrollDistance(0), _zoneEffect(0), _userChars(nullptr),
 _cBufSize(0), _cBuf(nullptr), _charSpacing(1), _fontDef(nullptr)
 #if ENA_SPRITE
 , _spriteInData(nullptr), _spriteOutData(nullptr)


### PR DESCRIPTION
The data members `_suspend` and `_lastRunTime` of class `MD_PZone` are not initialized explicitly, so they will contain random values when the `MD_Parola` object is created dynamically on the heap.

(In contrast, if an object is created statically, all its data members are automatically initialized with zeros.)

That leads to a problem in `MD_PZone::zoneAnimate` because this method returns early when `_suspend` is non-zero. In that case the LED display stays dark.

The change initializes `_suspend` to `false` and `_lastRunTime` to `0` in the `MD_PZone` constructor.