### PR TITLE
Correct dependency name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,5 +8,5 @@ category=Display
 url=https://github.com/MajicDesigns/MD_Parola
 architectures=*
 includes=MD_Parola.h,MD_MAX72xx.h,SPI.h
-depends=MD_MAX72xx
+depends=MD_MAX72XX
 license=LGPL-2.1


### PR DESCRIPTION
Previously, the library.properties `depends` field was defined as `MD_MAX72xx`, but the library name is `MD_MAX72XX` and the Arduino Library Manager dependencies system is case sensitive.
![Clipboard01](https://user-images.githubusercontent.com/8572152/71584631-58364980-2ac8-11ea-9423-c4e3e6c0b261.png)
