### PR TITLE
Suggestion for 3.5.2

### DIFF
--- a/src/MD_Parola.h
+++ b/src/MD_Parola.h
@@ -1345,9 +1345,9 @@ public:
   /**
    * Set the current animation to end for all zones.
    *
-   * This method is used to set all the zone animations an animation to the end
-   * of their cycle current cycle.
-   * It is normally invoked when you before to start a new animation that as to
+   * This method is used to set all the zone animations to the end of their cycle
+   * current cycle.
+   * It is normally invoked before to invoke a new animation that as to
    * start immediately
    *
    * \return No return value.


### PR DESCRIPTION
- Added displayAnimationTerminate to terminate an animation
- Renamed setSpeed(uint16_t speedIn, uint16_t speedOut) in setSpeedInOut

displayAnimationTerminate is used to set a zone animation to the end of the current cycle.
It is normally invoked before to call a new animation that as to start immediately.